### PR TITLE
Add dry-run capability to application

### DIFF
--- a/app.py
+++ b/app.py
@@ -26,6 +26,8 @@ if 'client_id' not in st.session_state:
     st.session_state.client_id = None
 if 'client_secret' not in st.session_state:
     st.session_state.client_secret = None
+if 'dry_run' not in st.session_state:
+    st.session_state.dry_run = False
 
 # Define pages for navigation
 pages = [

--- a/game_renamer.py
+++ b/game_renamer.py
@@ -278,12 +278,13 @@ class GameFolderRenamer:
 
         return folders
 
-    def rename_folder(self, old_name: str, new_name: str) -> Dict[str, Any]:
+    def rename_folder(self, old_name: str, new_name: str, dry_run: bool = False) -> Dict[str, Any]:
         """Rename a single folder
 
         Args:
             old_name: Current folder name
             new_name: Desired folder name
+            dry_run: If True, only simulate the rename without actually performing it
 
         Returns:
             Dictionary with success status and details
@@ -296,11 +297,21 @@ class GameFolderRenamer:
             return {
                 'success': False,
                 'error': f'Folder "{new_name}" already exists',
-                'old_name': old_name
+                'old_name': old_name,
+                'dry_run': dry_run
+            }
+
+        if dry_run:
+            # Dry run mode - just simulate the rename
+            return {
+                'success': True,
+                'old_name': old_name,
+                'new_name': new_name,
+                'dry_run': True
             }
 
         try:
             os.rename(old_path, new_path)
-            return {'success': True, 'old_name': old_name, 'new_name': new_name}
+            return {'success': True, 'old_name': old_name, 'new_name': new_name, 'dry_run': False}
         except OSError as e:
-            return {'success': False, 'error': str(e), 'old_name': old_name}
+            return {'success': False, 'error': str(e), 'old_name': old_name, 'dry_run': False}

--- a/pages_nav/process.py
+++ b/pages_nav/process.py
@@ -40,6 +40,18 @@ def _check_connection() -> bool:
 
 def _render_action_buttons() -> None:
     """Render the main action buttons (Scan, Process, Clear)"""
+    # Dry-run toggle
+    st.session_state.dry_run = st.checkbox(
+        "🔍 Dry Run Mode (Preview changes without actually renaming)",
+        value=st.session_state.get('dry_run', False),
+        help="When enabled, rename operations will only show what would happen without actually renaming folders"
+    )
+
+    if st.session_state.dry_run:
+        st.info("ℹ️ Dry Run Mode is enabled - no folders will be renamed")
+
+    st.divider()
+
     col1, col2, col3 = st.columns([2, 2, 2])
 
     with col1:
@@ -198,13 +210,20 @@ def _handle_rename_folder(folder_name: str, new_name: str, result: Dict[str, Any
         new_name: New folder name
         result: Result dictionary to update
     """
-    with st.spinner(f"Renaming {folder_name}..."):
-        rename_result = st.session_state.renamer.rename_folder(folder_name, new_name)
+    dry_run = st.session_state.get('dry_run', False)
+    action = "Simulating rename" if dry_run else "Renaming"
+
+    with st.spinner(f"{action} {folder_name}..."):
+        rename_result = st.session_state.renamer.rename_folder(folder_name, new_name, dry_run=dry_run)
 
         if rename_result['success']:
-            st.success(f"Renamed to: {new_name}")
-            result['status'] = 'renamed'
-            st.rerun()
+            if rename_result.get('dry_run'):
+                st.success(f"✅ DRY RUN: Would rename to: {new_name}")
+                st.info("ℹ️ No actual changes were made. Disable dry-run mode to perform the rename.")
+            else:
+                st.success(f"Renamed to: {new_name}")
+                result['status'] = 'renamed'
+                st.rerun()
         else:
             st.error(f"Error: {rename_result['error']}")
 
@@ -273,14 +292,20 @@ def _handle_apply_selection(
         if selected_idx < len(games):
             selected_game = games[selected_idx]
             new_name = format_game_name(selected_game)
+            dry_run = st.session_state.get('dry_run', False)
+            action = "Simulating rename" if dry_run else "Renaming"
 
-            with st.spinner(f"Renaming {folder_name}..."):
-                rename_result = st.session_state.renamer.rename_folder(folder_name, new_name)
+            with st.spinner(f"{action} {folder_name}..."):
+                rename_result = st.session_state.renamer.rename_folder(folder_name, new_name, dry_run=dry_run)
 
                 if rename_result['success']:
-                    st.success(f"Renamed to: {new_name}")
-                    result['status'] = 'renamed'
-                    st.rerun()
+                    if rename_result.get('dry_run'):
+                        st.success(f"✅ DRY RUN: Would rename to: {new_name}")
+                        st.info("ℹ️ No actual changes were made. Disable dry-run mode to perform the rename.")
+                    else:
+                        st.success(f"Renamed to: {new_name}")
+                        result['status'] = 'renamed'
+                        st.rerun()
                 else:
                     st.error(f"Error: {rename_result['error']}")
 


### PR DESCRIPTION
Implements a dry-run mode that allows users to preview rename operations without actually modifying the filesystem. This feature enhances safety and gives users confidence before making bulk changes.

Changes:
- Added dry_run parameter to GameFolderRenamer.rename_folder() method
- Added dry_run flag to session state initialization
- Added UI checkbox toggle for dry-run mode in process page
- Updated both rename handlers (_handle_rename_folder and _handle_apply_selection) to respect dry-run mode and display appropriate feedback
- Dry-run results show clear indicators that no changes were made
- UI displays informational banner when dry-run mode is enabled

When dry-run is enabled:
- Rename operations are simulated without touching the filesystem
- Success messages clearly indicate "DRY RUN" status
- Users see what would happen before committing to actual changes