### PR TITLE
Fix Windows startup script to use virtual environment

### DIFF
--- a/run.bat
+++ b/run.bat
@@ -19,11 +19,31 @@ REM Display Python version
 for /f "tokens=2" %%i in ('python --version 2^>^&1') do set PYTHON_VERSION=%%i
 echo Python %PYTHON_VERSION% found
 
-REM Check if Streamlit is installed
+REM Virtual environment directory
+set VENV_DIR=venv
+
+REM Check if virtual environment exists
+if not exist "%VENV_DIR%\Scripts\activate.bat" (
+    echo.
+    echo Creating virtual environment...
+    python -m venv "%VENV_DIR%"
+    if errorlevel 1 (
+        echo.
+        echo Error: Failed to create virtual environment
+        pause
+        exit /b 1
+    )
+    echo Virtual environment created
+)
+
+REM Activate virtual environment
+call "%VENV_DIR%\Scripts\activate.bat"
+
+REM Check if Streamlit is installed in the virtual environment
 python -c "import streamlit" >nul 2>&1
 if errorlevel 1 (
     echo.
-    echo Streamlit not found. Installing dependencies...
+    echo Installing dependencies in virtual environment...
     pip install -r requirements.txt
     if errorlevel 1 (
         echo.


### PR DESCRIPTION
The run.bat script was installing dependencies globally instead of in a
virtual environment, unlike the Linux/Mac run.sh script. This caused
inconsistent behavior across platforms and could lead to package conflicts.

Changes:
- Add virtual environment creation if venv doesn't exist
- Activate venv before checking/installing dependencies
- Install Streamlit and dependencies inside venv, not globally
- Match the behavior of run.sh for cross-platform consistency

Now Windows users get the same isolated environment as Linux/Mac users.